### PR TITLE
Fix for permission error.

### DIFF
--- a/docker/profile-renderer/Dockerfile
+++ b/docker/profile-renderer/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git && apt-get -y install sudo
 
 COPY . /usr/publisher
 WORKDIR /usr/publisher
@@ -10,6 +10,11 @@ RUN chmod +x entrypoint.sh
 # Create a non-root user for our FHIR publisher to run as
 RUN groupadd -r fhir -g 1000 && \
     useradd -u 1000 -r -g fhir fhir
+# Add fhir user to sudo
+RUN adduser fhir sudo
+# Run sudo with no password prompt
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# Change owner and group to fhir on publisher location
 RUN chown -R fhir:fhir /usr/publisher
 
 USER fhir

--- a/docker/profile-renderer/entrypoint.sh
+++ b/docker/profile-renderer/entrypoint.sh
@@ -11,10 +11,11 @@ OUT_PATH=$6
 RENDERER_FLAGS=${RENDERER_FLAGS}
 
 # First, clone the repository with our source files
-rm -Rf /source/files
+sudo rm -Rf /source/files
+sudo chown -R fhir:fhir /source 
+
 git clone $GITHUB_URL /source/files
 
-chown 100:1000 /source/files
 chmod g=rwx,o= /source/files
 
 cd /source/files
@@ -25,6 +26,15 @@ cd /source/files/$REPO_PATH/
 if [ ! -z "$OLD_URL" ] && [ ! -z "$NEW_URL" ]; then
   echo "Doing URL replacement: OLD_URL=$OLD_URL NEW_URL=$NEW_URL"
   find . -name "*.xml" -type f -exec sed -i -e "s|$OLD_URL|$NEW_URL|g" {} \;
+fi
+
+#TODO check directory exists
+if [ -d /generated ]
+then
+  sudo chown -R fhir:fhir /generated
+else
+  sudo mkdir /generated
+  sudo chown -R fhir:fhir /generated
 fi
 
 mkdir -p /generated/$OUT_PATH


### PR DESCRIPTION
@GeoffreyHayward, @marcusfearnett-nhsdigital, Updated the docker file to add fhir to sudo and allow sudo to be ran without a password.  Used sudo to chown directories that were complaining to fhir:fhir user and group that was set up in the script.  

Tested on jenkins and is passing after @marcusfearnett-nhsdigital made a tweak to https://github.com/nhsconnect/STU3-FHIR-Assets 