### PR TITLE
Remove test banner

### DIFF
--- a/reference-server-lib/src/main/resources/hl7-velocity-templates/list.vm
+++ b/reference-server-lib/src/main/resources/hl7-velocity-templates/list.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<h2 class='resourceType'>$resourceType.getDisplayName() Resources</h2>

--- a/reference-server-lib/src/main/resources/hl7-velocity-templates/raw-resource.vm
+++ b/reference-server-lib/src/main/resources/hl7-velocity-templates/raw-resource.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<div class='$class'><pre lang='$lang'>$rawContent</pre></div>

--- a/reference-server-lib/src/main/resources/hl7-velocity-templates/search-results.vm
+++ b/reference-server-lib/src/main/resources/hl7-velocity-templates/search-results.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<h2 class='resourceType'>$resourceType.getDisplayName() Resources</h2>

--- a/reference-server-lib/src/main/resources/velocity-templates/list.vm
+++ b/reference-server-lib/src/main/resources/velocity-templates/list.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<h2 class='resourceType'>$resourceType.getDisplayName() Resources</h2>

--- a/reference-server-lib/src/main/resources/velocity-templates/raw-resource.vm
+++ b/reference-server-lib/src/main/resources/velocity-templates/raw-resource.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<div class='$class'><pre lang='$lang'>$rawContent</pre></div>

--- a/reference-server-lib/src/main/resources/velocity-templates/resource-with-metadata.vm
+++ b/reference-server-lib/src/main/resources/velocity-templates/resource-with-metadata.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 	#if( $hasGeneratedMetadataFromRenderer )
 		#parse( "/velocity-templates/resource-metadata-from-renderer.vm" )

--- a/reference-server-lib/src/main/resources/velocity-templates/search-results.vm
+++ b/reference-server-lib/src/main/resources/velocity-templates/search-results.vm
@@ -1,7 +1,4 @@
 <div class='fhirServerGeneratedContent'>
-	<div class='fhirServerNotice'>Important note: this server is no longer the master copy for CareConnect FHIR assets.
-	 The master copy with the latest versions is now hosted on the Simplifier development platform within the <a href="https://simplifier.net/hl7fhircareconnectbaselineforstu3">HL7 FHIR&reg; CareConnect Baseline for STU3 project</a>.
-	  This project contains the latest versions of the CareConnect FHIR assets in an <a href="https://simplifier.net/HL7FHIRCareConnectBaselineforSTU3/~packages"> NPM package</a> and a <a href="https://simplifier.net/guide/hl7fhircareconnectprofilesstu3?version=current">implementation guide</a>.</div>
 	<div class='fhirServerNotice'>This is a HL7 FHIR server, and as you appear to be accessing this page from a web browser you  are seeing a HTML version of the requested resource(s). You can also access this URL from a FHIR client as a ReSTful API call. For more details please see the <a href="https://www.hl7.org/fhir/">HL7 FHIR specification</a>.</div>
 
 	<h2 class='resourceType'>$resourceType.getDisplayName() Resources</h2>


### PR DESCRIPTION
Remove CareConnect banner.  Going forward there will be no deployment to https://fhir.hl7.org.uk, so committing the change to master.  Current docker image is tagged 1.4.5 (no banner), previous docker image is tagged 1.4.4 (with banner).